### PR TITLE
Use a path relative to the dependency root

### DIFF
--- a/etl/init.ts
+++ b/etl/init.ts
@@ -1,5 +1,6 @@
 import { DuckDBInstance } from "@duckdb/node-api";
+import path from "path";
 
-export const db = await DuckDBInstance.create("./data/census.db");
+export const db = await DuckDBInstance.create(path.join(__dirname, "..", "data", "census.db"));
 
 export const connection = await db.connect();


### PR DESCRIPTION
> [!WARNING]
> Might have to import `__dirname` before using it, but seems to be working in bun.

## Description
When we pass a normal file path string (e.g. "./data/mydb.db") to a library, it’s resolved relative to the current working directory (`process.cwd()`), not the file where the code lives. In most cases, when running the app from the project root, that means it’s relative to the app’s root folder, not the dependency’s folder. If we want the path to be relative to the file itself, we need to resolve it using `__dirname` and joining the relative path to it.

There may be some other spots where this needs to be applied, but this one change got it working on my end.

<img width="513" height="92" alt="image" src="https://github.com/user-attachments/assets/5f973c51-d47f-4c31-81a4-73601d082ea9" />

## Steps to Reproduce Issue
1. Add the better-census package
2. Run the `etl` script
3. Use the `Census.run()` to fetch some data in the root app directory. (Could be right in the app index.ts)
4. The dependency won't know where to find data/census.db

## Concerns
- Might have to import `__dirname` before using it with `import { dirname } from "node:path";`
- This tightly couples the etl directory to the data directory. If the data directory were to move, we'd have to update the path here too.

It assumes this directory structure.
```text 
├── etl
├── data
│   ├── raw
```