### PR TITLE
Make the encoder input optional

### DIFF
--- a/lib/census.ts
+++ b/lib/census.ts
@@ -32,14 +32,14 @@ export namespace Census {
 }
 
 export class Census<Enc extends Encoder.RootRecord> {
-  private internalEncoder: Enc;
+  private internalEncoder: Enc | undefined;
 
-  constructor(encoder: { items: Enc }) {
-    this.internalEncoder = encoder.items;
+  constructor(opts?: { items?: Enc }) {
+    this.internalEncoder = opts?.items;
   }
 
   get encoder() {
-    return Encoder.proxy(this.internalEncoder);
+    return Encoder.proxy(this.internalEncoder ?? {});
   }
 
   async run<


### PR DESCRIPTION
## Description

If no encoders are provided, it just defaults to an empty object.

This lets us write
```typescript
new Census()
```
instead of
```ts
new Census({ items: {} })
```
if we have no encoders made.