### PR TITLE
Modify etl script for dat parsing

### DIFF
--- a/etl/index.ts
+++ b/etl/index.ts
@@ -1,25 +1,21 @@
 import path from "node:path";
 import glob from "fast-glob";
 import { createLineStream } from "../util/stream";
-import { separateLine } from "../util/csv";
+import { separateLine as separateLineCSV } from "../util/csv";
 import { separateLine as separateLineDat } from "../util/dat";
 import { initializeDB } from "./init";
 
 const BASE_PATH = "./data/raw/";
 const BATCH_SIZE = 4000;
+
 const connection = await initializeDB();
-
-// const ids = await getAllIds();
-// await setupTable(ids);
-// await loadAll();
-
 const ids = await getAllIds();
 await setupTable(ids);
-// await loadAllDat();
+await loadAll();
 
 // 
 
-export async function getAllIds() {
+async function getAllIds() {
   const files = await glob(`${BASE_PATH}/**/*.{csv,dat}`).then((f) => f.map((file) => file.replace(BASE_PATH, "")));
 
   const ids = new Set<string>();
@@ -40,7 +36,7 @@ export async function getAllIds() {
   return ids;
 }
 
-export async function setupTable(ids: Set<string>) {  
+async function setupTable(ids: Set<string>) {  
   const q = `
     create or replace table data (
     id text primary key,
@@ -54,142 +50,120 @@ export async function setupTable(ids: Set<string>) {
   await connection.run(q);
 }
 
-export async function loadAllDat(){
-  const files = await glob(`${BASE_PATH}/**/*.dat`);
-  for(const file of files) {
+async function loadAll() {
+  const files = await glob(`${BASE_PATH}/**/*.{csv,dat}`);
+  for (const file of files) {
+    const fileType = getFileType(file);
+    if (fileType === "unknown") continue;
+
     const index = files.indexOf(file);
     console.log(`Loading ${index + 1}/${files.length}: ${file}`);
-    const csv = Bun.file(file).stream();
-    const lineStream = createLineStream(csv);
-    
-    const firstLine = await lineStream.next();
-    if(!firstLine.value) continue;
-    const columnLine = separateLineDat(firstLine.value);
 
-    const keptIndices = new Set<number>();
+    if (fileType === "dat") await parseDatFile(file);
+    if (fileType === "csv") await parseCsvFile(file);
+  }
+}
 
-    columnLine.forEach((col, index) => {
-      if(col.includes("_E") && col !== "NAME") {
-        keptIndices.add(index);
-      }
-    });
-    
-    const columns = [...keptIndices].map(i => columnLine[i]);
-    console.log("--", columns.length, "columns in", file);
-
-    let i = 0;
-    const chunks: (string | number)[][] = [];
-
-    const limit = 10;
-    let l = 0;
-    for await(const line of lineStream) {
-      if (l > limit) break;
+async function parseDatFile(filePath: string){
+  const fileStream = Bun.file(filePath).stream();
+  const lineStream = createLineStream(fileStream);
+  
+  const firstLine = await lineStream.next();
+  if(!firstLine.value) return;
+  
+  // Select Columns
+  const columnLine = separateLineDat(firstLine.value);
+  const selectedIndices = new Set<number>();
+  columnLine.forEach((col, index) => {
+    if (col.includes("_E")) selectedIndices.add(index);
+  });
+  
+  const selectedColumns = [...selectedIndices].map(i => columnLine[i]);
+  console.log("--", selectedColumns.length, "columns in", filePath);
+  
+  // Insert Rows
+  let rows = 0;
+  const valuesBatch: (string | number)[][] = [];
+  for await (const line of lineStream) {
+    const split = separateLineDat(line);
+    const geoID = split[0]!;
+    const selectedValues = split.filter((_, idx) => selectedIndices.has(idx)).map(parseNumber);
       
-      const split = separateLineDat(line);
-      const chunkLine = split
-        .filter((_, i) => keptIndices.has(i))
-        .map(val => {
-          const asNumber = Number(val);
-          if(isNaN(asNumber)) return "NULL";
-          return asNumber;
-        });
-      const geoId = split[0]! as string;
-      if (!geoId.startsWith("06000")) continue;
+    // if (!geoID.startsWith("06000")) continue;
 
-      const chunk = [`'${geoId}'`, ...chunkLine];
-      chunks.push(chunk);
+    const queryValues = [`'${geoID}'`, ...selectedValues];
+    valuesBatch.push(queryValues);
 
-      if(chunks.length >= BATCH_SIZE) {
-        i += chunks.length;
-        const q = `
-          insert into data (id, ${columns.join(", ")})
-          values ${chunks.map(chunk => `(${chunk.join(", ")})`).join(",\n  ")}
-          on conflict (id) do update set
-            ${columns.map((col, i) => `"${col}" = excluded."${col}"`).join(",\n  ")}
-        `;
+    if (valuesBatch.length >= BATCH_SIZE) {
+      await insertValuesBatch(valuesBatch, selectedColumns);
+      rows += valuesBatch.length;
+      console.log("  --", `Inserted ${valuesBatch.length} rows for ${filePath}`);
 
-        await connection.run(q);
-        console.log("  --", `Inserted ${chunks.length} rows for ${file}`);
-
-        chunks.length = 0;
-      }
+      valuesBatch.length = 0;
     }
+  }
 
-    console.log("--", `Loaded ${file} with ${i} rows`);
+  console.log("--", `Loaded ${filePath} with ${rows} rows`);
+}
+
+async function parseCsvFile(filePath: string){
+  const fileStream = Bun.file(filePath).stream();
+  const lineStream = createLineStream(fileStream);
+  
+  const firstLine = await lineStream.next();
+  if(!firstLine.value) return;
+  
+  // Select Columns
+  const columnLine = separateLineCSV(firstLine.value);
+  const selectedIndices = new Set<number>();
+  columnLine.forEach((col, index) => {
+    if (col.endsWith("E") && col !== "NAME") selectedIndices.add(index);
+  });
+  
+  const selectedColumns = [...selectedIndices].map(i => columnLine[i]);
+  console.log("--", selectedColumns.length, "columns in", filePath);
+  
+  // Skip label line
+  const _ = lineStream.next();
+  
+  // Insert Rows
+  let rows = 0;
+  const valuesBatch: (string | number)[][] = [];
+  for await (const line of lineStream) {
+    const split = separateLineCSV(line);
+    const geoID = split[0]!;
+    const selectedValues = split.filter((_, idx) => selectedIndices.has(idx)).map(parseNumber);
+      
+    const queryValues = [`'${geoID}'`, ...selectedValues];
+    valuesBatch.push(queryValues);
+
+    if (valuesBatch.length >= BATCH_SIZE) {
+      await insertValuesBatch(valuesBatch, selectedColumns);
+      rows += valuesBatch.length;
+      console.log("  --", `Inserted ${valuesBatch.length} rows for ${filePath}`);
+
+      valuesBatch.length = 0;
+    }
   }
   
+  console.log("--", `Loaded ${filePath} with ${rows} rows`);
 }
 
-export async function loadAll() {
-  const files = await glob(`${BASE_PATH}/**/*.csv`);
+async function insertValuesBatch(valueBatch: (string | number)[][], selectedColumns: (string | undefined)[]) {
+  const q = `
+    insert into data (id, ${selectedColumns.join(", ")})
+    values ${valueBatch.map((chunk) => `(${chunk.join(", ")})`).join(",\n  ")}
+    on conflict (id) do update set
+      ${selectedColumns.map((col, i) => `"${col}" = excluded."${col}"`).join(",\n  ")}
+  `;
 
-  for(const file of files) {
-    const index = files.indexOf(file);
-    console.log(`Loading ${index + 1}/${files.length}: ${file}`);
-    const csv = Bun.file(file).stream();
-    const lineStream = createLineStream(csv);
-
-    const firstLine = await lineStream.next();
-    if(!firstLine.value) continue;
-    const columnLine = separateLine(firstLine.value);
-
-    const keptIndices = new Set<number>();
-
-    columnLine.forEach((col, index) => {
-      if(col.endsWith("E") && col !== "NAME") {
-        keptIndices.add(index);
-      }
-    });
-
-    const columns = [...keptIndices].map(i => columnLine[i]);
-
-    console.log("--", columns.length, "columns in", file);
-
-    // label line
-    const _ = lineStream.next();
-
-    let i = 0;
-    const chunks: (string | number)[][] = [];
-
-    for await(const line of lineStream) {
-      const split = separateLine(line);
-      const chunkLine = split
-        .filter((_, i) => keptIndices.has(i))
-        .map(val => {
-          const asNumber = Number(val);
-          if(isNaN(asNumber)) return "NULL";
-          return asNumber;
-        });
-      const geoId = split[0]! as string;
-
-      chunks.push([`'${geoId}'`, ...chunkLine]);
-
-      if(chunks.length >= BATCH_SIZE) {
-        i += chunks.length;
-        const q = `
-insert into data (id, ${columns.join(", ")})
-values ${chunks.map(chunk => `(${chunk.join(", ")})`).join(",\n  ")}
-on conflict (id) do update set
-  ${columns.map((col, i) => `"${col}" = excluded."${col}"`).join(",\n  ")}
-        `;
-
-        await connection.run(q);
-        console.log("  --", `Inserted ${chunks.length} rows for ${file}`);
-
-        chunks.length = 0;
-      }
-    }
-
-    console.log("--", `Loaded ${file} with ${i} rows`);
-  }
+  await connection.run(q);
 }
-
-// 
 
 function extractEstimateColumns(line: string, fileType: "csv" | "dat") {
   switch (fileType) {
     case "csv":
-      return separateLine(line).filter((id) => id.endsWith("E") && id !== "NAME");
+      return separateLineCSV(line).filter((id) => id.endsWith("E") && id !== "NAME");
     case "dat":
       return separateLineDat(line).filter((id) => id.includes("_E") && id !== "NAME");
   }
@@ -199,4 +173,9 @@ function getFileType(file: string) {
   if (file.endsWith(".csv")) return "csv";
   if (file.endsWith(".dat")) return "dat";
   return "unknown";
+}
+
+function parseNumber(val: string) {
+  const asNumber = Number(val);
+  return isNaN(asNumber) ? "NULL" : asNumber;
 }

--- a/etl/index.ts
+++ b/etl/index.ts
@@ -2,7 +2,7 @@ import glob from "fast-glob";
 import path from "node:path";
 import { parseArgs } from "util";
 import { separateLine as separateLineCSV } from "../util/csv";
-import { separateLine as separateLineDat } from "../util/dat";
+import { correctDatColumnID, separateLine as separateLineDat } from "../util/dat";
 import { createLineStream } from "../util/stream";
 import { initializeDB } from "./init";
 
@@ -82,10 +82,10 @@ async function parseDatFile(filePath: string){
   if(!firstLine.value) return;
   
   // Select Columns
-  const columnLine = separateLineDat(firstLine.value);
+  const columnLine = separateLineDat(firstLine.value).map(correctDatColumnID);
   const selectedIndices = new Set<number>();
   columnLine.forEach((col, index) => {
-    if (col.includes("_E")) selectedIndices.add(index);
+    if (col.endsWith("E") && col !== "NAME") selectedIndices.add(index);
   });
   
   const selectedColumns = [...selectedIndices].map(i => columnLine[i]);
@@ -177,7 +177,7 @@ function extractEstimateColumns(line: string, fileType: "csv" | "dat") {
     case "csv":
       return separateLineCSV(line).filter((id) => id.endsWith("E") && id !== "NAME");
     case "dat":
-      return separateLineDat(line).filter((id) => id.includes("_E") && id !== "NAME");
+      return separateLineDat(line).filter((id) => id.includes("_E")).map(correctDatColumnID);
   }
 }
 

--- a/etl/index.ts
+++ b/etl/index.ts
@@ -2,6 +2,7 @@ import path from "node:path";
 import glob from "fast-glob";
 import { createLineStream } from "../util/stream";
 import { separateLine } from "../util/csv";
+import { separateLine as separateLineDat } from "../util/dat";
 import { initializeDB } from "./init";
 
 const connection = await initializeDB();
@@ -31,6 +32,30 @@ export async function getAllIds() {
   return ids;
 }
 
+export async function getAllDatIds() {
+  const files = await glob(`${basePath}/**/*.dat`)
+    .then(f => f.map(file => file
+      .replace(basePath, "")
+      .replace(/\.dat$/, "")));
+  
+  const ids = new Set<string>();
+
+  for(const file of files) {
+    const csv = Bun.file(path.join(`${basePath}/${file}.dat`)).stream();
+    const lineStream = createLineStream(csv);
+
+    const firstLine = await lineStream.next();
+    if(!firstLine.value) continue;
+
+    const split = separateLineDat(firstLine.value)
+      .filter(id => id.includes("_E") && id !== "NAME");
+    
+    split.forEach(id => ids.add(id));
+  }
+
+  return ids;
+}
+
 
 export async function setupTable(ids: Set<string>) {  
   const q = `
@@ -47,6 +72,72 @@ create or replace table data (
 }
 
 const BATCH_SIZE = 4000;
+
+export async function loadAllDat(){
+  const files = await glob(`${basePath}/**/*.dat`);
+  for(const file of files) {
+    const index = files.indexOf(file);
+    console.log(`Loading ${index + 1}/${files.length}: ${file}`);
+    const csv = Bun.file(file).stream();
+    const lineStream = createLineStream(csv);
+    
+    const firstLine = await lineStream.next();
+    if(!firstLine.value) continue;
+    const columnLine = separateLineDat(firstLine.value);
+
+    const keptIndices = new Set<number>();
+
+    columnLine.forEach((col, index) => {
+      if(col.includes("_E") && col !== "NAME") {
+        keptIndices.add(index);
+      }
+    });
+    
+    const columns = [...keptIndices].map(i => columnLine[i]);
+    console.log("--", columns.length, "columns in", file);
+
+    let i = 0;
+    const chunks: (string | number)[][] = [];
+
+    const limit = 10;
+    let l = 0;
+    for await(const line of lineStream) {
+      if (l > limit) break;
+      
+      const split = separateLineDat(line);
+      const chunkLine = split
+        .filter((_, i) => keptIndices.has(i))
+        .map(val => {
+          const asNumber = Number(val);
+          if(isNaN(asNumber)) return "NULL";
+          return asNumber;
+        });
+      const geoId = split[0]! as string;
+      if (!geoId.startsWith("06000")) continue;
+
+      const chunk = [`'${geoId}'`, ...chunkLine];
+      chunks.push(chunk);
+
+      if(chunks.length >= BATCH_SIZE) {
+        i += chunks.length;
+        const q = `
+          insert into data (id, ${columns.join(", ")})
+          values ${chunks.map(chunk => `(${chunk.join(", ")})`).join(",\n  ")}
+          on conflict (id) do update set
+            ${columns.map((col, i) => `"${col}" = excluded."${col}"`).join(",\n  ")}
+        `;
+
+        await connection.run(q);
+        console.log("  --", `Inserted ${chunks.length} rows for ${file}`);
+
+        chunks.length = 0;
+      }
+    }
+
+    console.log("--", `Loaded ${file} with ${i} rows`);
+  }
+  
+}
 
 export async function loadAll() {
   const files = await glob(`${basePath}/**/*.csv`);
@@ -112,7 +203,10 @@ on conflict (id) do update set
   }
 }
 
-const ids = await getAllIds();
-await setupTable(ids);
+// const ids = await getAllIds();
+// await setupTable(ids);
+// await loadAll();
 
-await loadAll();
+const ids = await getAllDatIds();
+await setupTable(ids);
+await loadAllDat();

--- a/util/dat.ts
+++ b/util/dat.ts
@@ -1,3 +1,12 @@
 export function separateLine(line: string) {
   return line.split("|").map((x) => x.trim());
 }
+
+export function correctDatColumnID(id: string){
+  const match = id.match(/^(.*?)_([A-Za-z])(\d+)$/);
+  if (match) {
+    const [, prefix, letter, number] = match;
+    return `${prefix}_${number}${letter}`;
+  }
+  return id;
+}

--- a/util/dat.ts
+++ b/util/dat.ts
@@ -1,0 +1,3 @@
+export function separateLine(line: string) {
+  return line.split("|").map((x) => x.trim());
+}


### PR DESCRIPTION
## Description
* Implements support for parsing `.dat` Census files
* Corrects the column ID format for .dat files
* Adds a new `--geoid` option for targeting specific Census GeoIDs with a regex pattern

## New `--geoid` usage
You can filter out a bunch of Census GeoIDs that you are not interested in adding the the local database with regex.
```bash
# Adds everything as usual.
bun etl

# Only adds county subdivision (starting with 0600000US) Census GeoIDs to the database.
bun etl --geoid "^0600000US"

# Only adds Hamden, Connecticut records to the database.
bun etl --geoid "0600000US0917035650"
```