### PR TITLE
Do not replace an existing data table

### DIFF
--- a/etl/index.ts
+++ b/etl/index.ts
@@ -124,9 +124,9 @@ async function getAllIds() {
 
 async function setupTable(ids: Set<string>) {
   const q = `
-    create or replace table data (
-    id text primary key,
-    ${[...ids].map((id) => `"${id}" real`).join(",\n  ")}
+    CREATE TABLE IF NOT EXISTS data (
+      id text primary key,
+      ${[...ids].map((id) => `"${id}" real`).join(",\n  ")}
     );
   `;
 


### PR DESCRIPTION
## Description
Each time the ETL script ran, it would replace the entire data table.
Switching to `CREATE TABLE IF NOT EXISTS` seems more appropriate here.