### PR TITLE
Fix import batches being dropped

### DIFF
--- a/etl/index.ts
+++ b/etl/index.ts
@@ -31,23 +31,21 @@ await main();
 async function main() {
   const dbExists = await Bun.file(DB_PATH).exists();
   // if (dbExists && !argValues.force) return console.log(`Database census.db already exists at ${DB_PATH}. Skipping ETL. Use --force to overwrite.`);
-  
+
   const error = await setupQueryService()
-  .then(() => false)
-  .catch((e) => e as Error);
+    .then(() => false)
+    .catch((e) => e as Error);
   if (error) {
     if (!(error instanceof Error && resourceIsLocked(error.message))) throw error;
-    console.error(
-      "The process cannot access the database file due to an IO Error.\nIf it's being hosted on a server, try running bun run etl --live instead."
-    );
+    console.error("The process cannot access the database file due to an IO Error.\nIf it's being hosted on a server, try running bun run etl --live instead.");
     return;
   }
-  
+
   if (dbExists && argValues.force) {
     console.log(`Database census.db already exists at ${DB_PATH}. Truncating all tables...`);
     await truncateDB();
   }
-  
+
   await setupFileTable();
   await setupGeocodingTables();
 
@@ -56,7 +54,7 @@ async function main() {
   await loadAll();
 }
 
-// 
+//
 
 async function truncateDB() {
   const allTables = await getAllTables();
@@ -65,11 +63,11 @@ async function truncateDB() {
   }
 }
 
-async function getAllTables(){
+async function getAllTables() {
   const q = `
     SELECT table_name FROM information_schema.tables;
   `;
-  const allTables = await queryService.query(q).then(records => records.map(record => record["table_name"]));
+  const allTables = await queryService.query(q).then((records) => records.map((record) => record["table_name"]));
   return allTables;
 }
 
@@ -226,12 +224,12 @@ async function parseDatFile(filePath: string) {
     const split = separateLineDat(line);
     const geoID = split[0]!;
     const selectedValues = split.filter((_, idx) => selectedIndices.has(idx)).map(parseNumber);
-    
+
     if (shouldSkip(geoID)) continue;
-    
+
     const queryValues = [`'${geoID}'`, ...selectedValues];
     valuesBatch.push(queryValues);
-        
+
     if (valuesBatch.length >= BATCH_SIZE) {
       await insertValuesBatch(valuesBatch, selectedColumns);
       rows += valuesBatch.length;
@@ -240,7 +238,7 @@ async function parseDatFile(filePath: string) {
       valuesBatch.length = 0;
     }
   }
-  
+
   if (valuesBatch.length) {
     await insertValuesBatch(valuesBatch, selectedColumns);
     rows += valuesBatch.length;
@@ -290,9 +288,9 @@ async function parseCsvFile(filePath: string) {
       console.log("  --", `Inserted ${valuesBatch.length} rows for ${fileName}`);
 
       valuesBatch.length = 0;
-    }  
+    }
   }
-  
+
   if (valuesBatch.length) {
     await insertValuesBatch(valuesBatch, selectedColumns);
     rows += valuesBatch.length;

--- a/etl/index.ts
+++ b/etl/index.ts
@@ -226,12 +226,12 @@ async function parseDatFile(filePath: string) {
     const split = separateLineDat(line);
     const geoID = split[0]!;
     const selectedValues = split.filter((_, idx) => selectedIndices.has(idx)).map(parseNumber);
-
+    
     if (shouldSkip(geoID)) continue;
-
+    
     const queryValues = [`'${geoID}'`, ...selectedValues];
     valuesBatch.push(queryValues);
-
+        
     if (valuesBatch.length >= BATCH_SIZE) {
       await insertValuesBatch(valuesBatch, selectedColumns);
       rows += valuesBatch.length;
@@ -239,6 +239,12 @@ async function parseDatFile(filePath: string) {
 
       valuesBatch.length = 0;
     }
+  }
+  
+  if (valuesBatch.length) {
+    await insertValuesBatch(valuesBatch, selectedColumns);
+    rows += valuesBatch.length;
+    console.log("  --", `Inserted ${valuesBatch.length} rows for ${fileName}`);
   }
 
   console.log("--", `Loaded ${filePath} with ${rows} rows`);
@@ -284,7 +290,13 @@ async function parseCsvFile(filePath: string) {
       console.log("  --", `Inserted ${valuesBatch.length} rows for ${fileName}`);
 
       valuesBatch.length = 0;
-    }
+    }  
+  }
+  
+  if (valuesBatch.length) {
+    await insertValuesBatch(valuesBatch, selectedColumns);
+    rows += valuesBatch.length;
+    console.log("  --", `Inserted ${valuesBatch.length} rows for ${fileName}`);
   }
 
   console.log("--", `Loaded ${filePath} with ${rows} rows`);


### PR DESCRIPTION
## Description
If the lineStream import loop ended with a batch size smaller than the `BATCH_SIZE` setting, it would drop whatever was remaining. 

* Adds an extra batch import after the lineStream loop

## Next Steps
I had to add the logic twice, one for CSV and one for DAT imports. Having only to spots isn't bad, but we could probably refactor this logic to be reusable.

Was also thinking about making a peekable iterator to check if the next line exists, then add the check to the batch import condition.
```typescript
function makePeekable<T>(iter: Iterator<T>) {
  let buffer: IteratorResult<T> | null = null
  return {
    peek() {
      if (!buffer) buffer = iter.next()
      return buffer
    },
    next() {
      if (buffer) { const v = buffer; buffer = null; return v }
      return iter.next()
    }
  }
}
```